### PR TITLE
Slightly tweak ffmpeg version parsing

### DIFF
--- a/src/AaxAudioConverterLib/FFmpeg.cs
+++ b/src/AaxAudioConverterLib/FFmpeg.cs
@@ -267,7 +267,7 @@ namespace audiamus.aaxconv.lib {
     private static readonly Regex _rgxDurationEx = new Regex (@"Duration:\s*?(\d+:\d+:\d+\.\d+).*bitrate:\s+(\d+)\s+kb/s",
       RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
-    private static readonly Regex _rgxVersion = new Regex (@"^ffmpeg version\s+([\d.]+)\s+", 
+    private static readonly Regex _rgxVersion = new Regex (@"^ffmpeg version\s+([\d.]+).+", 
       RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex _rgxMuxFinal = new Regex (@"video.*audio.*muxing overhead", 
       RegexOptions.Compiled | RegexOptions.IgnoreCase);


### PR DESCRIPTION
Allows some more (custom) ffmpeg builds to be used.

Now correctly parses builds like

```
FFmpeg 64-bit static Windows build from www.gyan.dev

Version: 4.3.1-2020-10-01-full_build-www.gyan.dev

```
