### PR TITLE
Bugfix for ffmpeg version parsing & allow nightly or private builds

### DIFF
--- a/src/AaxAudioConverter/FFmpegLocationForm.cs
+++ b/src/AaxAudioConverter/FFmpegLocationForm.cs
@@ -12,6 +12,7 @@ namespace audiamus.aaxconv {
   partial class FFmpegLocationForm : Form {
     readonly IAppSettings _settings = Properties.Settings.Default;
     readonly string _origFFMpegDirectory;
+    readonly bool? _relaxed;
 
     readonly AaxAudioConverter _converter;
     readonly Func<InteractionMessage, bool?> _callback;
@@ -19,10 +20,11 @@ namespace audiamus.aaxconv {
     private IAppSettings Settings => _settings;
 
 
-    public FFmpegLocationForm (AaxAudioConverter converter, Func<InteractionMessage, bool?> callback) {
+    public FFmpegLocationForm (AaxAudioConverter converter, Func<InteractionMessage, bool?> callback, bool? relaxed = null) {
       InitializeComponent ();
       _converter = converter;
       _callback = callback;
+      _relaxed = relaxed;
       _origFFMpegDirectory = Settings.FFMpegDirectory;
       textBoxLocation.Text = _origFFMpegDirectory;
     }
@@ -51,7 +53,7 @@ namespace audiamus.aaxconv {
       if (File.Exists (path))
         Settings.FFMpegDirectory = ffmpegdir;
 
-      bool succ = _converter.VerifyFFmpegPathVersion(_callback);
+      bool succ = _converter.VerifyFFmpegPathVersion(_callback, _relaxed);
 
       if (succ)
         enableOK ();

--- a/src/AaxAudioConverter/MainForm.cs
+++ b/src/AaxAudioConverter/MainForm.cs
@@ -459,7 +459,7 @@ namespace audiamus.aaxconv {
 
       if (!succ) {
 
-        FFmpegLocationForm dlg = new FFmpegLocationForm (_converter, _interactionHandler.Interact);
+        FFmpegLocationForm dlg = new FFmpegLocationForm (_converter, _interactionHandler.Interact, Settings.RelaxedFFmpegVersionCheck);
         var result = dlg.ShowDialog ();
         succ = result == DialogResult.OK;
       }

--- a/src/AaxAudioConverter/MainForm.cs
+++ b/src/AaxAudioConverter/MainForm.cs
@@ -182,7 +182,7 @@ namespace audiamus.aaxconv {
       if (args.Length > 1)
         addFile (args[1]);
 
-      await ensureFFmpegPathAsync ();
+      await ensureFFmpegPathAsync (Settings.RelaxedFFmpegVersionCheck);
     }
 
     protected override void OnLoad (EventArgs e) {
@@ -443,17 +443,17 @@ namespace audiamus.aaxconv {
       panelExec.Enabled = enable;
     }
 
-    private async Task ensureFFmpegPathAsync () {
+    private async Task ensureFFmpegPathAsync (bool acceptMismatchedVersion = false) {
       bool succ = false;
       if (!string.IsNullOrWhiteSpace (Settings.FFMpegDirectory)) {
-        succ = await _converter.VerifyFFmpegPathVersionAsync (_interactionHandler.Interact);
+        succ = await _converter.VerifyFFmpegPathVersionAsync (_interactionHandler.Interact, Settings.RelaxedFFmpegVersionCheck, acceptMismatchedVersion);
       } else {
         string ffmpegdir = ApplEnv.ApplDirectory;
         string path = Path.Combine (ffmpegdir, FFmpeg.FFMPEG_EXE);
         if (File.Exists (path)) {
           Settings.FFMpegDirectory = ffmpegdir;
           using (new ResourceGuard (() => Settings.FFMpegDirectory = null))
-            succ = await _converter.VerifyFFmpegPathVersionAsync (_interactionHandler.Interact);
+            succ = await _converter.VerifyFFmpegPathVersionAsync (_interactionHandler.Interact, Settings.RelaxedFFmpegVersionCheck, acceptMismatchedVersion);
         }
       }
 

--- a/src/AaxAudioConverter/SettingsForm.cs
+++ b/src/AaxAudioConverter/SettingsForm.cs
@@ -333,7 +333,7 @@ namespace audiamus.aaxconv {
 
     private void btnFfmpegLoc_Click (object sender, EventArgs e) {
       string oldSetting = _settings.FFMpegDirectory;
-      var dlg = new FFmpegLocationForm (_converter, _callback) { Owner = this };
+      var dlg = new FFmpegLocationForm (_converter, _callback, ckBoxFfmpegVersCheck.Checked) { Owner = this };
       dlg.ShowDialog ();
       string newSetting = _settings.FFMpegDirectory;
       Dirty |= string.Equals (newSetting, newSetting);

--- a/src/AaxAudioConverterLib/AaxAudioConverter.cs
+++ b/src/AaxAudioConverterLib/AaxAudioConverter.cs
@@ -159,12 +159,12 @@ namespace audiamus.aaxconv.lib {
     }
 
     public async Task<bool> VerifyFFmpegPathVersionAsync (
-      Func<InteractionMessage, bool?> callback, bool? relaxedFFmpegVersionCheck = null
+      Func<InteractionMessage, bool?> callback, bool? relaxedFFmpegVersionCheck = null, bool autoAcceptMismatch = false
     ) {
-      return await Task.Run (() => VerifyFFmpegPathVersion (callback, relaxedFFmpegVersionCheck));
+      return await Task.Run (() => VerifyFFmpegPathVersion (callback, relaxedFFmpegVersionCheck, autoAcceptMismatch));
     }
 
-    public bool VerifyFFmpegPathVersion (Func<InteractionMessage, bool?> callback, bool? relaxedFFmpegVersionCheck = null) {
+    public bool VerifyFFmpegPathVersion (Func<InteractionMessage, bool?> callback, bool? relaxedFFmpegVersionCheck = null, bool autoAcceptMismatch = false) {
       var version = VerifyFFmpegPath (relaxedFFmpegVersionCheck);
 
       bool succ = Version.TryParse(version, out Version parsedVersion);
@@ -176,7 +176,7 @@ namespace audiamus.aaxconv.lib {
         sb.AppendLine ($"{Resources.MsgFFmpegVersion3}?");
         sb.Append ($"({Resources.MsgFFmpegVersion4}.)");
 
-        succ = callback (new InteractionMessage { Message = sb.ToString (), Type = ECallbackType.question }) ?? false;
+        succ = autoAcceptMismatch || (callback(new InteractionMessage { Message = sb.ToString (), Type = ECallbackType.question }) ?? false);
       }
 
       return succ;

--- a/src/AaxAudioConverterLib/AaxAudioConverter.cs
+++ b/src/AaxAudioConverterLib/AaxAudioConverter.cs
@@ -144,7 +144,7 @@ namespace audiamus.aaxconv.lib {
       DefaultParallelOptions = null;
     }
 
-    public Version VerifyFFmpegPath (bool? relaxedFFmpegVersionCheck = null) {
+    public string VerifyFFmpegPath (bool? relaxedFFmpegVersionCheck = null) {
       var ffmpeg = new FFmpeg (null);
       Log (2, this, () => $"dir=\"{getFFmpegPath ().SubstitUser ()}\"");
       bool succ = ffmpeg.VerifyFFmpegPath (relaxedFFmpegVersionCheck ?? Settings.RelaxedFFmpegVersionCheck);
@@ -166,9 +166,10 @@ namespace audiamus.aaxconv.lib {
 
     public bool VerifyFFmpegPathVersion (Func<InteractionMessage, bool?> callback, bool? relaxedFFmpegVersionCheck = null) {
       var version = VerifyFFmpegPath (relaxedFFmpegVersionCheck);
-      bool succ = !version.IsNull();
 
-      if (succ && version < FFMPEG_VERSION) {
+      bool succ = Version.TryParse(version, out Version parsedVersion);
+
+      if ((succ && parsedVersion < FFMPEG_VERSION) || (!succ && relaxedFFmpegVersionCheck == true)) {
         var sb = new StringBuilder ();
         sb.AppendLine ($"{ApplName} {Resources.MsgFFmpegVersion1} {FFMPEG_VERSION}.");
         sb.AppendLine ($"{Resources.MsgFFmpegVersion2} {version}.");

--- a/src/AaxAudioConverterLib/FFmpeg.cs
+++ b/src/AaxAudioConverterLib/FFmpeg.cs
@@ -125,7 +125,7 @@ namespace audiamus.aaxconv.lib {
     internal bool IsAaxFile { get; private set; }
     internal bool HasNoActivation { get; private set; }
 
-    internal Version Version { get; private set; }
+    internal string Version { get; private set; }
 
     #endregion
     #region ctor
@@ -366,7 +366,7 @@ namespace audiamus.aaxconv.lib {
 
     private static readonly Regex _rgxVersion = new Regex (@"^ffmpeg version\s+([\d\.]+)[\s-_].*FFmpeg developers", 
       RegexOptions.Compiled | RegexOptions.IgnoreCase);
-    private static readonly Regex _rgxVersionRelaxed = new Regex (@"^ffmpeg version\s+\D*([\d\.]+).+", 
+    private static readonly Regex _rgxVersionRelaxed = new Regex (@"^ffmpeg version\s+(\S+)[\s-_].*FFmpeg developers", 
       RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex _rgxMuxFinal = new Regex (@"video.*audio.*muxing overhead", 
       RegexOptions.Compiled | RegexOptions.IgnoreCase);
@@ -428,10 +428,7 @@ namespace audiamus.aaxconv.lib {
         return;
 
       _success = true;
-      bool succ = Version.TryParse (match.Groups[1].Value, out Version version);
-
-      if (succ)
-        Version = version;
+      Version = match.Groups[1].Value;
     }
 
     private void ffMpegAsyncHandlerAudioMeta (object sendingProcess, DataReceivedEventArgs outLine) {


### PR DESCRIPTION
This is an updated PR to #38.

I recently found myself with a private custom build of ffmpeg (to use all those lovely non-free parts) but that build _just_ _would_ _not_ _get_ _accepted_ by AaxAudioConverter.

Turns out there was 
1. A bug in the "relaxed version parsing" logic. 
2. Even the relaxed version parsing would never accept any private build.

Basically even if you have ticked "relaxed version parsing" that would never get passed to the "locate ffmpeg exe" form, which thus would reject any unexpected build. Fixed that :grin:.
Also turned the `Version` field into an actual `string` since you'll *never* get private builds to return any sort of numerical version and as far as I can see the field only ever gets used in the "expected version X, but we would Y, are you sure?" dialog.

---
The custom version I happened to create was 
```
C:\FFMPEG\shared\ffmpeg.exe -version
ffmpeg version N-103356-g57de75bff1 Copyright (c) 2000-2021 the FFmpeg developers
built with gcc 10.3.0 (Rev5, Built by MSYS2 project)
...
```
and actually looking at the ffmpeg source at https://git.ffmpeg.org/gitweb/ffmpeg.git/blob/HEAD:/ffbuild/version.sh & https://git.ffmpeg.org/gitweb/ffmpeg.git/blob/HEAD:/fftools/cmdutils.c#l1149 there are a multitude of possible formats for the "version" so not insisting on a numerical one is actually in line with ffmpeg's definitions.

Since this already requires a "allow custom option" and will trigger a "expected version X, but we would Y, are you sure?" confirmation this should be totally fine.

