### PR TITLE
Update to .NET 7 and also nuget dependencies to current

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+.vs
+bin
+obj
+packages
+*.bak
+/src/AaxAudioConverter/*.user
+/src/AaxAudioConverter/FodyWeavers.xsd
+/src/AaxAudioConverter/ffmpeg.exe
+/src/AaxAudioConverter/ffmpeg64.exe
+

--- a/src/AAX Audio Converter.sln
+++ b/src/AAX Audio Converter.sln
@@ -1,30 +1,30 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.31205.134
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AaxAudioConverter", "AaxAudioConverter\AaxAudioConverter.csproj", "{D186DE5D-0DEC-4FE8-80BC-9F473E804604}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AaxAudioConverter", "AaxAudioConverter\AaxAudioConverter.csproj", "{D186DE5D-0DEC-4FE8-80BC-9F473E804604}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AuxLib", "AuxLib\AuxLib.csproj", "{64C35BCC-BF7A-47BE-89F2-7ABB470BDB0B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AuxLib", "AuxLib\AuxLib.csproj", "{64C35BCC-BF7A-47BE-89F2-7ABB470BDB0B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AuxWinLib", "AuxWinLib\AuxWinLib.csproj", "{D3ED00A5-5855-40F4-AEB8-BB9EEF35B7F7}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AuxWinLib", "AuxWinLib\AuxWinLib.csproj", "{D3ED00A5-5855-40F4-AEB8-BB9EEF35B7F7}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AaxAudioConverterLib", "AaxAudioConverterLib\AaxAudioConverterLib.csproj", "{724C151F-65E8-4108-8CFB-AE2FD4C63033}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AaxAudioConverterLib", "AaxAudioConverterLib\AaxAudioConverterLib.csproj", "{724C151F-65E8-4108-8CFB-AE2FD4C63033}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AuxWin.DialogBox", "AuxWinLib\DialogBox\AuxWin.DialogBox.csproj", "{D8E74EAE-8661-4764-BAEF-E9E138779D85}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AuxWin.DialogBox", "AuxWinLib\DialogBox\AuxWin.DialogBox.csproj", "{D8E74EAE-8661-4764-BAEF-E9E138779D85}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PropGridLib", "PropGridLib\PropGridLib.csproj", "{7B091DC6-75AA-403C-AD5E-EA3CB6610CD0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PropGridLib", "PropGridLib\PropGridLib.csproj", "{7B091DC6-75AA-403C-AD5E-EA3CB6610CD0}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AuxWin32Lib", "AuxWin32Lib\AuxWin32Lib.csproj", "{66AF7DB4-AA8E-45F5-BB1B-919C5008E6B0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AuxWin32Lib", "AuxWin32Lib\AuxWin32Lib.csproj", "{66AF7DB4-AA8E-45F5-BB1B-919C5008E6B0}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "InnoSetup", "InnoSetup", "{0C275DDF-DE38-4547-A835-6C121199055A}"
 	ProjectSection(SolutionItems) = preProject
 		InnoSetup\AaxAudioConverter setup.iss = InnoSetup\AaxAudioConverter setup.iss
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TreeDecomposition", "TreeDecomposition\TreeDecomposition.csproj", "{BBEFB463-1F6C-4D35-AF83-B5C3CEA9915E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TreeDecomposition", "TreeDecomposition\TreeDecomposition.csproj", "{BBEFB463-1F6C-4D35-AF83-B5C3CEA9915E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PerfLib", "PerfLib\PerfLib.csproj", "{AB642D01-29BF-4FBC-A001-E1795AC38108}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PerfLib", "PerfLib\PerfLib.csproj", "{AB642D01-29BF-4FBC-A001-E1795AC38108}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/AaxAudioConverter/AaxAudioConverter.csproj
+++ b/src/AaxAudioConverter/AaxAudioConverter.csproj
@@ -1,20 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Costura.Fody.4.1.0\build\Costura.Fody.props" Condition="Exists('..\packages\Costura.Fody.4.1.0\build\Costura.Fody.props')" />
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{D186DE5D-0DEC-4FE8-80BC-9F473E804604}</ProjectGuid>
+    <TargetFramework>net7.0-windows</TargetFramework>
     <OutputType>WinExe</OutputType>
     <RootNamespace>audiamus.aaxconv</RootNamespace>
-    <AssemblyName>AaxAudioConverter</AssemblyName>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <Deterministic>true</Deterministic>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
@@ -30,31 +18,10 @@
     <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
-    <TargetFrameworkProfile />
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
-    <Prefer32Bit>false</Prefer32Bit>
-    <LangVersion>7.3</LangVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <LangVersion>7.3</LangVersion>
-    <Prefer32Bit>false</Prefer32Bit>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <UseWindowsForms>true</UseWindowsForms>
+    <UseWPF>true</UseWPF>
+    <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationIcon>Resources\audio.ico</ApplicationIcon>
@@ -63,275 +30,17 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Costura, Version=4.1.0.0, Culture=neutral, PublicKeyToken=9919ef960d84173d, processorArchitecture=MSIL">
-      <HintPath>..\packages\Costura.Fody.4.1.0\lib\net40\Costura.dll</HintPath>
-    </Reference>
-    <Reference Include="CustomMarshalers" />
-    <Reference Include="Microsoft.WindowsAPICodePack, Version=1.1.4.0, Culture=neutral, PublicKeyToken=8985beaab7ea3f04, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft-WindowsAPICodePack-Core.1.1.4\lib\net48\Microsoft.WindowsAPICodePack.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.WindowsAPICodePack.Shell, Version=1.1.4.0, Culture=neutral, PublicKeyToken=8985beaab7ea3f04, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft-WindowsAPICodePack-Shell.1.1.4\lib\net48\Microsoft.WindowsAPICodePack.Shell.dll</HintPath>
-    </Reference>
-    <Reference Include="PresentationCore" />
-    <Reference Include="PresentationFramework" />
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xaml" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Deployment" />
-    <Reference Include="System.Drawing" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Windows.Forms" />
-    <Reference Include="System.Xml" />
-    <Reference Include="WindowsBase" />
-    <Reference Include="WindowsFormsIntegration" />
+    <ProjectReference Include="..\AaxAudioConverterLib\AaxAudioConverterLib.csproj" />
+    <ProjectReference Include="..\AuxLib\AuxLib.csproj" />
+    <ProjectReference Include="..\AuxWin32Lib\AuxWin32Lib.csproj" />
+    <ProjectReference Include="..\AuxWinLib\AuxWinLib.csproj" />
+    <ProjectReference Include="..\AuxWinLib\DialogBox\AuxWin.DialogBox.csproj" />
+    <ProjectReference Include="..\PerfLib\PerfLib.csproj" />
+    <ProjectReference Include="..\PropGridLib\PropGridLib.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="AaxFileItemEx.cs" />
-    <Compile Include="AboutForm.cs">
-      <SubType>Form</SubType>
-    </Compile>
-    <Compile Include="AboutForm.Designer.cs">
-      <DependentUpon>AboutForm.cs</DependentUpon>
-    </Compile>
-    <Compile Include="ActivationCodeForm.cs">
-      <SubType>Form</SubType>
-    </Compile>
-    <Compile Include="ActivationCodeForm.Designer.cs">
-      <DependentUpon>ActivationCodeForm.cs</DependentUpon>
-    </Compile>
-    <Compile Include="FileAssoc.cs" />
-    <Compile Include="FileDetailsForm.cs">
-      <SubType>Form</SubType>
-    </Compile>
-    <Compile Include="FileDetailsForm.Designer.cs">
-      <DependentUpon>FileDetailsForm.cs</DependentUpon>
-    </Compile>
-    <Compile Include="FileItemForm.cs">
-      <SubType>Form</SubType>
-    </Compile>
-    <Compile Include="GenresForm.cs">
-      <SubType>Form</SubType>
-    </Compile>
-    <Compile Include="GenresForm.Designer.cs">
-      <DependentUpon>GenresForm.cs</DependentUpon>
-    </Compile>
-    <Compile Include="PerformanceHandler.cs" />
-    <Compile Include="PreviewForm.cs">
-      <SubType>Form</SubType>
-    </Compile>
-    <Compile Include="PreviewForm.Designer.cs">
-      <DependentUpon>PreviewForm.cs</DependentUpon>
-    </Compile>
-    <Compile Include="ProgressProcessor.cs" />
-    <Compile Include="Properties\Resources.Designer.cs">
-      <AutoGen>True</AutoGen>
-      <DesignTime>True</DesignTime>
-      <DependentUpon>Resources.resx</DependentUpon>
-    </Compile>
-    <Compile Include="Properties\Settings.Designer.cs">
-      <AutoGen>True</AutoGen>
-      <DesignTimeSharedInput>True</DesignTimeSharedInput>
-      <DependentUpon>Settings.settings</DependentUpon>
-    </Compile>
-    <Compile Include="Resources.cs" />
-    <Compile Include="SettingsForm.cs">
-      <SubType>Form</SubType>
-    </Compile>
-    <Compile Include="SettingsForm.Designer.cs">
-      <DependentUpon>SettingsForm.cs</DependentUpon>
-    </Compile>
-    <Compile Include="TypeConvertersRM.cs" />
-    <Compile Include="FFmpegLocationForm.cs">
-      <SubType>Form</SubType>
-    </Compile>
-    <Compile Include="FFmpegLocationForm.Designer.cs">
-      <DependentUpon>FFmpegLocationForm.cs</DependentUpon>
-    </Compile>
-    <Compile Include="MainForm.cs">
-      <SubType>Form</SubType>
-    </Compile>
-    <Compile Include="MainForm.Designer.cs">
-      <DependentUpon>MainForm.cs</DependentUpon>
-    </Compile>
-    <Compile Include="PGANaming.cs" />
-    <Compile Include="Program.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Settings.cs" />
-    <Compile Include="StartupTipForm.cs">
-      <SubType>Form</SubType>
-    </Compile>
-    <Compile Include="StartupTipForm.Designer.cs">
-      <DependentUpon>StartupTipForm.cs</DependentUpon>
-    </Compile>
-    <Compile Include="WhatsNewForm.cs">
-      <SubType>Form</SubType>
-    </Compile>
-    <Compile Include="WhatsNewForm.Designer.cs">
-      <DependentUpon>WhatsNewForm.cs</DependentUpon>
-    </Compile>
-    <EmbeddedResource Include="AboutForm.de.resx">
-      <DependentUpon>AboutForm.cs</DependentUpon>
-      <SubType>Designer</SubType>
-    </EmbeddedResource>
-    <EmbeddedResource Include="AboutForm.resx">
-      <DependentUpon>AboutForm.cs</DependentUpon>
-      <SubType>Designer</SubType>
-    </EmbeddedResource>
-    <EmbeddedResource Include="ActivationCodeForm.de.resx">
-      <DependentUpon>ActivationCodeForm.cs</DependentUpon>
-      <SubType>Designer</SubType>
-    </EmbeddedResource>
-    <EmbeddedResource Include="ActivationCodeForm.resx">
-      <DependentUpon>ActivationCodeForm.cs</DependentUpon>
-      <SubType>Designer</SubType>
-    </EmbeddedResource>
-    <EmbeddedResource Include="FFmpegLocationForm.de.resx">
-      <DependentUpon>FFmpegLocationForm.cs</DependentUpon>
-    </EmbeddedResource>
-    <EmbeddedResource Include="FFmpegLocationForm.resx">
-      <DependentUpon>FFmpegLocationForm.cs</DependentUpon>
-      <SubType>Designer</SubType>
-    </EmbeddedResource>
-    <EmbeddedResource Include="FileDetailsForm.de.resx">
-      <DependentUpon>FileDetailsForm.cs</DependentUpon>
-    </EmbeddedResource>
-    <EmbeddedResource Include="FileDetailsForm.resx">
-      <DependentUpon>FileDetailsForm.cs</DependentUpon>
-      <SubType>Designer</SubType>
-    </EmbeddedResource>
-    <EmbeddedResource Include="GenresForm.de.resx">
-      <DependentUpon>GenresForm.cs</DependentUpon>
-    </EmbeddedResource>
-    <EmbeddedResource Include="GenresForm.resx">
-      <DependentUpon>GenresForm.cs</DependentUpon>
-    </EmbeddedResource>
-    <EmbeddedResource Include="MainForm.de.resx">
-      <DependentUpon>MainForm.cs</DependentUpon>
-      <SubType>Designer</SubType>
-    </EmbeddedResource>
-    <EmbeddedResource Include="MainForm.resx">
-      <DependentUpon>MainForm.cs</DependentUpon>
-      <SubType>Designer</SubType>
-    </EmbeddedResource>
-    <EmbeddedResource Include="PGANaming.de.resx">
-      <DependentUpon>PGANaming.cs</DependentUpon>
-      <SubType>Designer</SubType>
-    </EmbeddedResource>
-    <EmbeddedResource Include="PGANaming.resx">
-      <DependentUpon>PGANaming.cs</DependentUpon>
-      <SubType>Designer</SubType>
-    </EmbeddedResource>
-    <EmbeddedResource Include="PreviewForm.de.resx">
-      <DependentUpon>PreviewForm.cs</DependentUpon>
-    </EmbeddedResource>
-    <EmbeddedResource Include="PreviewForm.resx">
-      <DependentUpon>PreviewForm.cs</DependentUpon>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Properties\Resources.de.resx">
-      <SubType>Designer</SubType>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Properties\Resources.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-      <SubType>Designer</SubType>
-      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
-    </EmbeddedResource>
-    <EmbeddedResource Include="SettingsForm.de.resx">
-      <DependentUpon>SettingsForm.cs</DependentUpon>
-      <SubType>Designer</SubType>
-    </EmbeddedResource>
-    <EmbeddedResource Include="SettingsForm.resx">
-      <DependentUpon>SettingsForm.cs</DependentUpon>
-      <SubType>Designer</SubType>
-    </EmbeddedResource>
-    <EmbeddedResource Include="StartupTipForm.de.resx">
-      <DependentUpon>StartupTipForm.cs</DependentUpon>
-    </EmbeddedResource>
-    <EmbeddedResource Include="StartupTipForm.resx">
-      <DependentUpon>StartupTipForm.cs</DependentUpon>
-      <SubType>Designer</SubType>
-    </EmbeddedResource>
-    <EmbeddedResource Include="WhatsNewForm.de.resx">
-      <DependentUpon>WhatsNewForm.cs</DependentUpon>
-    </EmbeddedResource>
-    <EmbeddedResource Include="WhatsNewForm.resx">
-      <DependentUpon>WhatsNewForm.cs</DependentUpon>
-      <SubType>Designer</SubType>
-    </EmbeddedResource>
-    <None Include="AaxAudioConverter.de.odt" />
-    <None Include="AaxAudioConverter.de.pdf">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="AaxAudioConverter.odt" />
-    <None Include="AaxAudioConverter.pdf">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="app.manifest" />
-    <None Include="packages.config">
-      <SubType>Designer</SubType>
-    </None>
-    <None Include="Properties\Settings.settings">
-      <Generator>SettingsSingleFileGenerator</Generator>
-      <SubType>Designer</SubType>
-      <LastGenOutput>Settings.Designer.cs</LastGenOutput>
-    </None>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="App.config">
-      <SubType>Designer</SubType>
-    </None>
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\AaxAudioConverterLib\AaxAudioConverterLib.csproj">
-      <Project>{724c151f-65e8-4108-8cfb-ae2fd4c63033}</Project>
-      <Name>AaxAudioConverterLib</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\AuxLib\AuxLib.csproj">
-      <Project>{64C35BCC-BF7A-47BE-89F2-7ABB470BDB0B}</Project>
-      <Name>AuxLib</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\AuxWin32Lib\AuxWin32Lib.csproj">
-      <Project>{66AF7DB4-AA8E-45F5-BB1B-919C5008E6B0}</Project>
-      <Name>AuxWin32Lib</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\AuxWinLib\AuxWinLib.csproj">
-      <Project>{d3ed00a5-5855-40f4-aeb8-bb9eef35b7f7}</Project>
-      <Name>AuxWinLib</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\AuxWinLib\DialogBox\AuxWin.DialogBox.csproj">
-      <Project>{d8e74eae-8661-4764-baef-e9e138779d85}</Project>
-      <Name>AuxWin.DialogBox</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\PerfLib\PerfLib.csproj">
-      <Project>{AB642D01-29BF-4FBC-A001-E1795AC38108}</Project>
-      <Name>PerfLib</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\PropGridLib\PropGridLib.csproj">
-      <Project>{7B091DC6-75AA-403C-AD5E-EA3CB6610CD0}</Project>
-      <Name>PropGridLib</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="Resources\added.png" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="Resources\blank.png" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="AaxAudioConverter.latest.de.rtf" />
-    <None Include="AaxAudioConverter.latest.rtf" />
-    <Content Include="ffmpeg.exe">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
     <Content Include="Resources\hidden features de.png" />
     <Content Include="Resources\hidden features en.png" />
-    <None Include="ffmpeg64.exe">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
     <Content Include="FodyWeavers.xml" />
     <Content Include="Resources\audio.ico" />
     <Content Include="Resources\audio.png" />
@@ -348,13 +57,33 @@
       <Install>false</Install>
     </BootstrapperPackage>
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Fody.6.6.0\build\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.6.6.0\build\Fody.targets'))" />
-    <Error Condition="!Exists('..\packages\Costura.Fody.4.1.0\build\Costura.Fody.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Costura.Fody.4.1.0\build\Costura.Fody.props'))" />
-  </Target>
-  <Import Project="..\packages\Fody.6.6.0\build\Fody.targets" Condition="Exists('..\packages\Fody.6.6.0\build\Fody.targets')" />
+  <ItemGroup>
+    <PackageReference Include="Costura.Fody"
+                      Version="5.7.0">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Fody" Version="6.8.0" />
+    <PackageReference Include="Microsoft-WindowsAPICodePack-Core" Version="1.1.5" />
+    <PackageReference Include="Microsoft-WindowsAPICodePack-Shell" Version="1.1.5" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="System.ComponentModel.Composition" Version="7.0.0" />
+    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
+    <PackageReference Include="System.Runtime.Handles" Version="4.3.0" />
+    <PackageReference Include="Microsoft.NETCore.Platforms" Version="7.0.4" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="7.0.2" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Update="Properties\Settings.Designer.cs">
+      <DesignTimeSharedInput>True</DesignTimeSharedInput>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Settings.settings</DependentUpon>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="Properties\Settings.settings">
+      <Generator>SettingsSingleFileGenerator</Generator>
+      <LastGenOutput>Settings.Designer.cs</LastGenOutput>
+    </None>
+  </ItemGroup>
 </Project>

--- a/src/AaxAudioConverter/App.config
+++ b/src/AaxAudioConverter/App.config
@@ -1,206 +1,254 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
   <configSections>
-    <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-      <section name="audiamus.aaxconv.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
+    <sectionGroup name="userSettings"
+                  type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" >
+      <section name="audiamus.aaxconv.Properties.Settings"
+               type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+               allowExeDefinition="MachineToLocalUser"
+               requirePermission="false" />
     </sectionGroup>
-    <sectionGroup name="applicationSettings" type="System.Configuration.ApplicationSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-      <section name="audiamus.aaxconv.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
+    <sectionGroup name="applicationSettings"
+                  type="System.Configuration.ApplicationSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" >
+      <section name="audiamus.aaxconv.Properties.Settings"
+               type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+               requirePermission="false" />
     </sectionGroup>
   </configSections>
-  <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />
-  </startup>
-  
-  <System.Windows.Forms.ApplicationConfigurationSection>
-    <add key="DpiAwareness" value="PerMonitorV2" />
-  </System.Windows.Forms.ApplicationConfigurationSection>
-  
   <userSettings>
     <audiamus.aaxconv.Properties.Settings>
-      <setting name="InputDirectory" serializeAs="String">
+      <setting name="InputDirectory"
+               serializeAs="String">
         <value />
       </setting>
-      <setting name="OutputDirectory" serializeAs="String">
+      <setting name="OutputDirectory"
+               serializeAs="String">
         <value />
       </setting>
-      <setting name="FFMpegDirectory" serializeAs="String">
+      <setting name="FFMpegDirectory"
+               serializeAs="String">
         <value />
       </setting>
-      <setting name="RelaxedFFmpegVersionCheck" serializeAs="String">
+      <setting name="RelaxedFFmpegVersionCheck"
+               serializeAs="String">
         <value>False</value>
       </setting>
-      <setting name="FileDateColumn" serializeAs="String">
+      <setting name="FileDateColumn"
+               serializeAs="String">
         <value>False</value>
       </setting>
-      <setting name="ConvFormat" serializeAs="String">
+      <setting name="ConvFormat"
+               serializeAs="String">
         <value>mp3</value>
       </setting>
-      <setting name="ConvMode" serializeAs="String">
+      <setting name="ConvMode"
+               serializeAs="String">
         <value>chapters</value>
       </setting>
-      <setting name="TrkDurMins" serializeAs="String">
+      <setting name="TrkDurMins"
+               serializeAs="String">
         <value>5</value>
       </setting>
-      <setting name="FileNaming" serializeAs="String">
+      <setting name="FileNaming"
+               serializeAs="String">
         <value>track_book_author</value>
       </setting>
-      <setting name="TitleNaming" serializeAs="String">
+      <setting name="TitleNaming"
+               serializeAs="String">
         <value>track_book</value>
       </setting>
-      <setting name="TrackNumbering" serializeAs="String">
+      <setting name="TrackNumbering"
+               serializeAs="String">
         <value>track</value>
       </setting>
-      <setting name="TotalTracks" serializeAs="String">
+      <setting name="TotalTracks"
+               serializeAs="String">
         <value>False</value>
       </setting>
-      <setting name="GenreNaming" serializeAs="String">
+      <setting name="GenreNaming"
+               serializeAs="String">
         <value>standard</value>
       </setting>
-      <setting name="GenreName" serializeAs="String">
+      <setting name="GenreName"
+               serializeAs="String">
         <value />
       </setting>
-      <setting name="ChapterNaming" serializeAs="String">
+      <setting name="ChapterNaming"
+               serializeAs="String">
         <value>standard</value>
       </setting>
-      <setting name="ChapterName" serializeAs="String">
+      <setting name="ChapterName"
+               serializeAs="String">
         <value />
       </setting>
-      <setting name="SeriesTitleLeft" serializeAs="String">
+      <setting name="SeriesTitleLeft"
+               serializeAs="String">
         <value>False</value>
       </setting>
-      <setting name="LongBookTitle" serializeAs="String">
+      <setting name="LongBookTitle"
+               serializeAs="String">
         <value>no</value>
       </setting>
-      <setting name="PartNaming" serializeAs="String">
+      <setting name="PartNaming"
+               serializeAs="String">
         <value>standard</value>
       </setting>
-      <setting name="PartName" serializeAs="String">
+      <setting name="PartName"
+               serializeAs="String">
         <value />
       </setting>
-      <setting name="Language" serializeAs="String">
+      <setting name="Language"
+               serializeAs="String">
         <value />
       </setting>
-      <setting name="PartNames" serializeAs="String">
+      <setting name="PartNames"
+               serializeAs="String">
         <value />
       </setting>
-      <setting name="AddnlValTitlePunct" serializeAs="String">
+      <setting name="AddnlValTitlePunct"
+               serializeAs="String">
         <value />
       </setting>
-      <setting name="Genres" serializeAs="String">
+      <setting name="Genres"
+               serializeAs="String">
         <value />
       </setting>
-      <setting name="FlatFolders" serializeAs="String">
+      <setting name="FlatFolders"
+               serializeAs="String">
         <value>False</value>
       </setting>
-      <setting name="FlatFolderNaming" serializeAs="String">
+      <setting name="FlatFolderNaming"
+               serializeAs="String">
         <value>author_book</value>
       </setting>
-      <setting name="WithSeriesTitle" serializeAs="String">
+      <setting name="WithSeriesTitle"
+               serializeAs="String">
         <value>True</value>
       </setting>
-      <setting name="NumDigitsSeriesSeqNo" serializeAs="String">
+      <setting name="NumDigitsSeriesSeqNo"
+               serializeAs="String">
         <value>2</value>
       </setting>
-      <setting name="FullCaptionBookFolder" serializeAs="String">
+      <setting name="FullCaptionBookFolder"
+               serializeAs="String">
         <value>False</value>
       </setting>
-      <setting name="OutFolderConflict" serializeAs="String">
+      <setting name="OutFolderConflict"
+               serializeAs="String">
         <value>ask</value>
       </setting>
-      <setting name="ExtraMetaFiles" serializeAs="String">
+      <setting name="ExtraMetaFiles"
+               serializeAs="String">
         <value>False</value>
       </setting>
-      <setting name="OnlineUpdate" serializeAs="String">
+      <setting name="OnlineUpdate"
+               serializeAs="String">
         <value>promptForInstall</value>
       </setting>
-      <setting name="ShortChapterSec" serializeAs="String">
+      <setting name="ShortChapterSec"
+               serializeAs="String">
         <value>25</value>
       </setting>
-      <setting name="VeryShortChapterSec" serializeAs="String">
+      <setting name="VeryShortChapterSec"
+               serializeAs="String">
         <value>10</value>
       </setting>
-      <setting name="VerifyAdjustChapterMarks" serializeAs="String">
+      <setting name="VerifyAdjustChapterMarks"
+               serializeAs="String">
         <value>splitChapterOrTimeMode</value>
       </setting>
-      <setting name="Latin1EncodingForPlaylist" serializeAs="String">
+      <setting name="Latin1EncodingForPlaylist"
+               serializeAs="String">
         <value>False</value>
       </setting>
-      <setting name="IntermedCopySingle" serializeAs="String">
+      <setting name="IntermedCopySingle"
+               serializeAs="String">
         <value>False</value>
       </setting>
-      <setting name="FixAACEncoding" serializeAs="String">
+      <setting name="FixAACEncoding"
+               serializeAs="String">
         <value>withIntermediateCopy</value>
       </setting>
-      <setting name="NamedChapters" serializeAs="String">
+      <setting name="NamedChapters"
+               serializeAs="String">
         <value>yes</value>
       </setting>
-      <setting name="VariableBitRate" serializeAs="String">
+      <setting name="VariableBitRate"
+               serializeAs="String">
         <value>False</value>
       </setting>
-      <setting name="ReducedBitRate" serializeAs="String">
+      <setting name="ReducedBitRate"
+               serializeAs="String">
         <value>off</value>
       </setting>
-      <setting name="AutoLaunchPlayer" serializeAs="String">
+      <setting name="AutoLaunchPlayer"
+               serializeAs="String">
         <value>True</value>
       </setting>
-      <setting name="M4B" serializeAs="String">
+      <setting name="M4B"
+               serializeAs="String">
         <value>True</value>
       </setting>
-      <setting name="AaxCopyMode" serializeAs="String">
+      <setting name="AaxCopyMode"
+               serializeAs="String">
         <value>no</value>
       </setting>
-      <setting name="AaxCopyDirectory" serializeAs="String">
+      <setting name="AaxCopyDirectory"
+               serializeAs="String">
         <value />
       </setting>
-      <setting name="Version" serializeAs="String">
+      <setting name="Version"
+               serializeAs="String">
         <value />
       </setting>
-      <setting name="SettingsTab" serializeAs="String">
+      <setting name="SettingsTab"
+               serializeAs="String">
         <value>0</value>
       </setting>
-      <setting name="PreferEmbeddedChapterTimes" serializeAs="String">
+      <setting name="PreferEmbeddedChapterTimes"
+               serializeAs="String">
         <value>no</value>
       </setting>
-      <setting name="TagArtist" serializeAs="String">
+      <setting name="TagArtist"
+               serializeAs="String">
         <value>author__narrator__</value>
       </setting>
-      <setting name="TagAlbumArtist" serializeAs="String">
+      <setting name="TagAlbumArtist"
+               serializeAs="String">
         <value>none</value>
       </setting>
-      <setting name="TagComposer" serializeAs="String">
+      <setting name="TagComposer"
+               serializeAs="String">
         <value>none</value>
       </setting>
-      <setting name="TagConductor" serializeAs="String">
+      <setting name="TagConductor"
+               serializeAs="String">
         <value>none</value>
       </setting>
-      <setting name="OnlineUpdateOthersDeclined" serializeAs="String">
+      <setting name="OnlineUpdateOthersDeclined"
+               serializeAs="String">
         <value />
       </setting>
     </audiamus.aaxconv.Properties.Settings>
   </userSettings>
   <applicationSettings>
     <audiamus.aaxconv.Properties.Settings>
-      <setting name="NonParallel" serializeAs="String">
+      <setting name="NonParallel"
+               serializeAs="String">
         <value>False</value>
       </setting>
-      <setting name="FFmpeg64bitHours" serializeAs="String">
+      <setting name="FFmpeg64bitHours"
+               serializeAs="String">
         <value>0</value>
       </setting>
-      <setting name="OnlineUpdateUrl" serializeAs="String">
+      <setting name="OnlineUpdateUrl"
+               serializeAs="String">
         <value />
       </setting>
-      <setting name="OnlineUpdateDebug" serializeAs="String">
+      <setting name="OnlineUpdateDebug"
+               serializeAs="String">
         <value>False</value>
       </setting>
     </audiamus.aaxconv.Properties.Settings>
   </applicationSettings>
-  <runtime>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
-      </dependentAssembly>
-    </assemblyBinding>
-  </runtime>
 </configuration>

--- a/src/AaxAudioConverter/Program.cs
+++ b/src/AaxAudioConverter/Program.cs
@@ -25,6 +25,7 @@ namespace audiamus.aaxconv {
           Logging.Level = (int)loglevel;
         }
 
+        Application.SetHighDpiMode(HighDpiMode.PerMonitorV2);
         Application.EnableVisualStyles ();
         Application.SetCompatibleTextRenderingDefault (false);
 

--- a/src/AaxAudioConverter/Properties/AssemblyInfo.cs
+++ b/src/AaxAudioConverter/Properties/AssemblyInfo.cs
@@ -2,6 +2,9 @@
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+
+[assembly: SupportedOSPlatform("windows")]
 
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information

--- a/src/AaxAudioConverter/Properties/Settings.Designer.cs
+++ b/src/AaxAudioConverter/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace audiamus.aaxconv.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.4.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.7.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));

--- a/src/AaxAudioConverter/WhatsNewForm.resx
+++ b/src/AaxAudioConverter/WhatsNewForm.resx
@@ -183,18 +183,6 @@
   <data name="btnOK.Text" xml:space="preserve">
     <value>OK</value>
   </data>
-  <data name="&gt;&gt;btnOK.Name" xml:space="preserve">
-    <value>btnOK</value>
-  </data>
-  <data name="&gt;&gt;btnOK.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnOK.Parent" xml:space="preserve">
-    <value>panel1</value>
-  </data>
-  <data name="&gt;&gt;btnOK.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="lblPrev.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Left</value>
   </data>
@@ -212,18 +200,6 @@
   </data>
   <data name="lblPrev.Text" xml:space="preserve">
     <value>For release notes to previous versions see the manual.</value>
-  </data>
-  <data name="&gt;&gt;lblPrev.Name" xml:space="preserve">
-    <value>lblPrev</value>
-  </data>
-  <data name="&gt;&gt;lblPrev.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblPrev.Parent" xml:space="preserve">
-    <value>panel1</value>
-  </data>
-  <data name="&gt;&gt;lblPrev.ZOrder" xml:space="preserve">
-    <value>1</value>
   </data>
   <data name="richTextBox1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>

--- a/src/AaxAudioConverter/packages.config
+++ b/src/AaxAudioConverter/packages.config
@@ -1,7 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Costura.Fody" version="4.1.0" targetFramework="net48" />
-  <package id="Fody" version="6.6.0" targetFramework="net48" developmentDependency="true" />
-  <package id="Microsoft-WindowsAPICodePack-Core" version="1.1.4" targetFramework="net48" />
-  <package id="Microsoft-WindowsAPICodePack-Shell" version="1.1.4" targetFramework="net48" />
-</packages>

--- a/src/AaxAudioConverterLib/AaxAudioConverterLib.csproj
+++ b/src/AaxAudioConverterLib/AaxAudioConverterLib.csproj
@@ -1,125 +1,31 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{724C151F-65E8-4108-8CFB-AE2FD4C63033}</ProjectGuid>
+    <TargetFramework>net7.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>audiamus.aaxconv.lib</RootNamespace>
-    <AssemblyName>AaxAudioConverterLib</AssemblyName>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <Deterministic>true</Deterministic>
-    <TargetFrameworkProfile />
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <LangVersion>7.1</LangVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <LangVersion>7.1</LangVersion>
+    <AssemblyTitle>AaxAudioConverterLib</AssemblyTitle>
+    <Company>audiamus</Company>
+    <Product>AaxAudioConverterLib</Product>
+    <Copyright>Copyright © 2019 - 2023 audiamus</Copyright>
+    <AssemblyVersion>1.18.2.0</AssemblyVersion>
+    <FileVersion>1.18.2.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="ATL, Version=4.20.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\z440.atl.core.4.20.0\lib\net48\ATL.dll</HintPath>
-    </Reference>
-    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.13.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.6.0.0\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
-    <Reference Include="Ude.NetStandard, Version=1.0.2.0, Culture=neutral, PublicKeyToken=103cb45fc06c90e4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Ude.NetStandard.1.2.0\lib\net45\Ude.NetStandard.dll</HintPath>
-    </Reference>
+    <ProjectReference Include="..\AuxLib\AuxLib.csproj" />
+    <ProjectReference Include="..\AuxWin32Lib\AuxWin32Lib.csproj" />
+    <ProjectReference Include="..\TreeDecomposition\TreeDecomposition.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="AaxAudioConverter.Nested.cs" />
-    <Compile Include="AaxFileCopier.cs" />
-    <Compile Include="ActivationCodeApp.cs" />
-    <Compile Include="ActivationCodeRegistry.cs" />
-    <Compile Include="AudibleAppContentMetadata.cs" />
-    <Compile Include="AudibleAppSimsBySeries.cs" />
-    <Compile Include="Book.Part.cs" />
-    <Compile Include="ContentMetadata.json.cs" />
-    <Compile Include="ExtraMetaFiles.cs" />
-    <Compile Include="FFMetaData.cs" />
-    <Compile Include="FileEx.cs" />
-    <Compile Include="FixAtomESDS.cs" />
-    <Compile Include="OnlineUpdate.cs" />
-    <Compile Include="ChainPunctuation.cs" />
-    <Compile Include="AudioMeta.cs" />
-    <Compile Include="CustomTagFileNames.cs" />
-    <Compile Include="Extensions.cs" />
-    <Compile Include="Chapter.cs" />
-    <Compile Include="Interfaces.cs" />
-    <Compile Include="Book.Progress.cs" />
-    <Compile Include="SeriesTitles.json.cs" />
-    <Compile Include="SimsBySeries.json.cs" />
-    <Compile Include="ThreadProgress.cs" />
-    <Compile Include="ToStringConverters.cs" />
-    <Compile Include="Track.cs" />
-    <Compile Include="ProgressMessage.cs" />
-    <Compile Include="ResourceInterface.cs" />
-    <Compile Include="TagAndFileNamingHelper.Numbers.cs" />
-    <Compile Include="TagAndFileNamingHelper.cs" />
-    <Compile Include="AaxFileItem.cs" />
-    <Compile Include="ActivationCode.cs" />
-    <Compile Include="CallbackWrapper.cs" />
-    <Compile Include="AaxAudioConverter.cs" />
-    <Compile Include="Enums.cs" />
-    <Compile Include="FFmpeg.cs" />
-    <Compile Include="SettingsInterface.cs" />
-    <Compile Include="Book.cs" />
-    <Compile Include="ChapteredTracks.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="TimeInterval.cs" />
-    <Compile Include="UpdatePackageInfo.cs" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
+    <PackageReference Include="Ude.NetStandard" Version="1.2.0" />
+    <PackageReference Include="z440.atl.core" Version="5.9.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\AuxLib\AuxLib.csproj">
-      <Project>{64C35BCC-BF7A-47BE-89F2-7ABB470BDB0B}</Project>
-      <Name>AuxLib</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\AuxWin32Lib\AuxWin32Lib.csproj">
-      <Project>{66AF7DB4-AA8E-45F5-BB1B-919C5008E6B0}</Project>
-      <Name>AuxWin32Lib</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\TreeDecomposition\TreeDecomposition.csproj">
-      <Project>{BBEFB463-1F6C-4D35-AF83-B5C3CEA9915E}</Project>
-      <Name>TreeDecomposition</Name>
-    </ProjectReference>
+    <Compile Remove="ContentMetaDataJson.cs" />
   </ItemGroup>
-  <ItemGroup>
-    <None Include="app.config" />
-    <None Include="packages.config">
-      <SubType>Designer</SubType>
-    </None>
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/AaxAudioConverterLib/CallbackWrapper.cs
+++ b/src/AaxAudioConverterLib/CallbackWrapper.cs
@@ -10,7 +10,7 @@ namespace audiamus.aaxconv.lib {
     readonly IInteractionCallback<InteractionMessage, bool?> _interaction;
 
     public CancellationToken CancellationToken => _token;
-    public bool Cancelled => _token != null ? _token.IsCancellationRequested : false;  
+    public bool Cancelled => _token.IsCancellationRequested;  
 
     public CallbackWrapper (CancellationToken token, IProgress<ProgressMessage> progress, IInteractionCallback<InteractionMessage, bool?> interaction = null) {
       _token = token;
@@ -19,7 +19,7 @@ namespace audiamus.aaxconv.lib {
     }
 
     public bool Cancel () {
-      return _token != null ? _token.IsCancellationRequested : false;
+      return _token.IsCancellationRequested;
     }
 
     public void Progress (ProgressMessage msg) {

--- a/src/AaxAudioConverterLib/Properties/AssemblyInfo.cs
+++ b/src/AaxAudioConverterLib/Properties/AssemblyInfo.cs
@@ -1,6 +1,9 @@
 ﻿using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+
+[assembly: SupportedOSPlatform("windows")]
 
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information

--- a/src/AaxAudioConverterLib/packages.config
+++ b/src/AaxAudioConverterLib/packages.config
@@ -1,8 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Newtonsoft.Json" version="13.0.2" targetFramework="net48" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="net48" />
-  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
-  <package id="Ude.NetStandard" version="1.2.0" targetFramework="net48" />
-  <package id="z440.atl.core" version="4.20.0" targetFramework="net48" />
-</packages>

--- a/src/AuxLib/ApplEnv.cs
+++ b/src/AuxLib/ApplEnv.cs
@@ -20,7 +20,7 @@ namespace audiamus.aux {
 
     public static Version AssemblyVersion { get; } = EntryAssembly.GetName ().Version;
     public static string AssemblyTitle { get; } = 
-      getAttribute<AssemblyTitleAttribute> ()?.Title ?? Path.GetFileNameWithoutExtension (ExecutingAssembly.CodeBase);
+      getAttribute<AssemblyTitleAttribute> ()?.Title ?? Path.GetFileNameWithoutExtension (ExecutingAssembly.Location);
     public static string AssemblyProduct { get; } = getAttribute<AssemblyProductAttribute> ()?.Product;
     public static string AssemblyCopyright { get; } = getAttribute<AssemblyCopyrightAttribute> ()?.Copyright;
     public static string AssemblyCompany { get; } = getAttribute<AssemblyCompanyAttribute> ()?.Company;

--- a/src/AuxLib/AuxLib.csproj
+++ b/src/AuxLib/AuxLib.csproj
@@ -1,75 +1,17 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{64C35BCC-BF7A-47BE-89F2-7ABB470BDB0B}</ProjectGuid>
+    <TargetFramework>net7.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>audiamus.aux</RootNamespace>
     <AssemblyName>UtilLib</AssemblyName>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <Deterministic>true</Deterministic>
-    <TargetFrameworkProfile />
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <LangVersion>7.3</LangVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <LangVersion>7.3</LangVersion>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <AssemblyTitle>AuxLib</AssemblyTitle>
+    <Company>audiamus</Company>
+    <Product>AuxLib</Product>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Configuration" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="7.0.0" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="ApplEnv.cs" />
-    <Compile Include="ArgParser.cs" />
-    <Compile Include="BigEndianReader.cs" />
-    <Compile Include="BooleanYesNoConverter.cs" />
-    <Compile Include="ChainPunctuation.cs" />
-    <Compile Include="DefaultSettings.cs" />
-    <Compile Include="Encoding.cs" />
-    <Compile Include="EnumChainTypeConverter.cs" />
-    <Compile Include="EnumUtil.cs" />
-    <Compile Include="ExtensionMethods.cs" />
-    <Compile Include="Indent.cs" />
-    <Compile Include="InteractionMessage.cs" />
-    <Compile Include="Interfaces.cs" />
-    <Compile Include="LocalFileSettingsProvider.cs" />
-    <Compile Include="Logging.cs" />
-    <Compile Include="EnumConverter.cs" />
-    <Compile Include="ProcessHost.cs" />
-    <Compile Include="IInteractionCallback.cs" />
-    <Compile Include="InteractionCallback.cs" />
-    <Compile Include="ProcessList.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="ResourceGuard.cs" />
-    <Compile Include="ResourceManagerEx.cs" />
-    <Compile Include="Singleton.cs" />
-    <Compile Include="Temp.cs" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/AuxLib/Encoding.cs
+++ b/src/AuxLib/Encoding.cs
@@ -6,6 +6,6 @@ using System.Threading.Tasks;
 
 namespace audiamus.aux {
   public abstract class Encoding : System.Text.Encoding {
-    public static System.Text.Encoding Latin1 => System.Text.Encoding.GetEncoding ("ISO-8859-1");
+    public new static System.Text.Encoding Latin1 => System.Text.Encoding.GetEncoding ("ISO-8859-1");
   }
 }

--- a/src/AuxWin32Lib/Properties/AssemblyInfo.cs
+++ b/src/AuxWin32Lib/Properties/AssemblyInfo.cs
@@ -1,6 +1,9 @@
 ﻿using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+
+[assembly: SupportedOSPlatform("windows")]
 
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information

--- a/src/AuxWin32Lib/auxWin32Lib.csproj
+++ b/src/AuxWin32Lib/auxWin32Lib.csproj
@@ -1,52 +1,13 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{66AF7DB4-AA8E-45F5-BB1B-919C5008E6B0}</ProjectGuid>
+    <TargetFramework>net7.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>audiamus.aux.w32</RootNamespace>
-    <AssemblyName>AuxWin32Lib</AssemblyName>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <Deterministic>true</Deterministic>
-    <TargetFrameworkProfile />
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="FileAssociation.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Win32FileIO.cs" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/AuxWinLib/AuxWinLib.csproj
+++ b/src/AuxWinLib/AuxWinLib.csproj
@@ -1,72 +1,27 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{D3ED00A5-5855-40F4-AEB8-BB9EEF35B7F7}</ProjectGuid>
+    <TargetFramework>net7.0-windows</TargetFramework>
     <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>audiamus.aux.win</RootNamespace>
     <AssemblyName>AuxLib</AssemblyName>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <Deterministic>true</Deterministic>
-    <TargetFrameworkProfile />
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <LangVersion>7.3</LangVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <LangVersion>7.3</LangVersion>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <UseWindowsForms>true</UseWindowsForms>
+    <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Drawing" />
-    <Reference Include="System.Windows.Forms" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="ComboBoxEnumAdapter.cs" />
-    <Compile Include="Culture.cs" />
-    <Compile Include="RtfBuilder.cs" />
-    <Compile Include="SystemMenu.cs" />
-    <Compile Include="ControlExPathEllipsis.cs" />
-    <Compile Include="InteractionCallbackHandler.cs" />
-    <Compile Include="ListViewColumnSorter.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="VerticalProgressBar.cs">
+    <Compile Update="VerticalProgressBar.cs">
       <SubType>Component</SubType>
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\AuxLib\AuxLib.csproj">
-      <Project>{64c35bcc-bf7a-47be-89f2-7abb470bdb0b}</Project>
-      <Name>AuxLib</Name>
-    </ProjectReference>
-    <ProjectReference Include="DialogBox\AuxWin.DialogBox.csproj">
-      <Project>{d8e74eae-8661-4764-baef-e9e138779d85}</Project>
-      <Name>AuxWin.DialogBox</Name>
-    </ProjectReference>
+    <ProjectReference Include="..\AuxLib\AuxLib.csproj" />
+    <ProjectReference Include="DialogBox\AuxWin.DialogBox.csproj" />
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Remove="DialogBox\**" />
+  </ItemGroup>
 </Project>

--- a/src/AuxWinLib/ControlExPathEllipsis.cs
+++ b/src/AuxWinLib/ControlExPathEllipsis.cs
@@ -1,6 +1,8 @@
 ﻿using System.Drawing;
 using System.Windows.Forms;
 
+using static System.Windows.Forms.Design.AxImporter;
+
 namespace audiamus.aux.win.ex {
   public static class ControlExPathEllipsis {
     public static void SetTextAsPathWithEllipsis (this Control label, string text = null) {
@@ -8,14 +10,51 @@ namespace audiamus.aux.win.ex {
         text = (string)label.Tag;
       else
         label.Tag = text;
-      string text2 = string.Copy (text);
-      Size size = new Size (label.Width - 8, label.Height);
-      TextRenderer.MeasureText (text2, label.Font,
-        size, TextFormatFlags.ModifyString | TextFormatFlags.PathEllipsis);
-      int pos = text2.IndexOf ('\0');
-      if (pos >= 0)
-        text2 = text2.Substring (0, pos);
+      string text2 = Compact(text, label);
       label.Text = text2;
     }
-  }
+    // adapted from https://www.codeproject.com/Articles/37503/Auto-Ellipsis
+    private static string Compact(string text, Control ctrl)
+    {
+        using Graphics dc = ctrl.CreateGraphics();
+        Size s = TextRenderer.MeasureText(dc, text, ctrl.Font);
+
+        // control is large enough to display the whole text 
+        if (s.Width <= ctrl.Width - 8)
+            return text;
+
+        int len = 0;
+        int seg = text.Length;
+        string fit = "";
+
+        // find the longest string that fits into
+        // the control boundaries using bisection method 
+        while (seg > 1)
+        {
+            seg -= seg / 2;
+
+            int left = len + seg;
+            int right = text.Length;
+            if (left > right)
+                continue;
+
+            // build and measure a candidate string with ellipsis
+            string tst = text.Substring(0, left) +
+                "..." + text.Substring(right);
+
+            s = TextRenderer.MeasureText(dc, tst, ctrl.Font);
+
+            // candidate string fits into control boundaries, 
+            // try a longer string
+            // stop when seg <= 1 
+            if (s.Width <= ctrl.Width - 8)
+            {
+                len += seg;
+                fit = tst;
+            }
+        }
+
+        return len == 0 ? "..." : fit;
+    }
+    }
 }

--- a/src/AuxWinLib/DialogBox/AuxWin.DialogBox.csproj
+++ b/src/AuxWinLib/DialogBox/AuxWin.DialogBox.csproj
@@ -1,14 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="12.0">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <TargetFramework>net7.0-windows</TargetFramework>
     <ProjectType>Local</ProjectType>
-    <ProductVersion>8.0.50727</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{D8E74EAE-8661-4764-BAEF-E9E138779D85}</ProjectGuid>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ApplicationIcon>
-    </ApplicationIcon>
     <AssemblyKeyContainerName>
     </AssemblyKeyContainerName>
     <AssemblyName>WindowsDialogBox</AssemblyName>
@@ -23,108 +16,61 @@
     <RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
     <StartupObject>
     </StartupObject>
-    <FileUpgradeFlags>
-    </FileUpgradeFlags>
-    <UpgradeBackupLocation>
-    </UpgradeBackupLocation>
-    <OldToolsVersion>3.5</OldToolsVersion>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
-    <TargetFrameworkProfile />
     <SccProjectName>Svn</SccProjectName>
     <SccLocalPath>Svn</SccLocalPath>
     <SccAuxPath>Svn</SccAuxPath>
     <SccProvider>SubversionScc</SccProvider>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <UseWindowsForms>true</UseWindowsForms>
+    <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <OutputPath>bin\Debug\</OutputPath>
-    <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
     <BaseAddress>285212672</BaseAddress>
-    <CheckForOverflowUnderflow>false</CheckForOverflowUnderflow>
     <ConfigurationOverrideFile>
     </ConfigurationOverrideFile>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
     <DocumentationFile>
     </DocumentationFile>
-    <DebugSymbols>true</DebugSymbols>
     <FileAlignment>4096</FileAlignment>
     <NoStdLib>false</NoStdLib>
     <NoWarn>
     </NoWarn>
-    <Optimize>false</Optimize>
     <RegisterForComInterop>false</RegisterForComInterop>
     <RemoveIntegerChecks>false</RemoveIntegerChecks>
-    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
-    <WarningLevel>4</WarningLevel>
-    <DebugType>full</DebugType>
-    <ErrorReport>prompt</ErrorReport>
-    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <OutputPath>bin\Release\</OutputPath>
-    <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
     <BaseAddress>285212672</BaseAddress>
-    <CheckForOverflowUnderflow>false</CheckForOverflowUnderflow>
     <ConfigurationOverrideFile>
     </ConfigurationOverrideFile>
-    <DefineConstants>TRACE</DefineConstants>
     <DocumentationFile>
     </DocumentationFile>
-    <DebugSymbols>false</DebugSymbols>
     <FileAlignment>4096</FileAlignment>
     <NoStdLib>false</NoStdLib>
     <NoWarn>
     </NoWarn>
-    <Optimize>true</Optimize>
     <RegisterForComInterop>false</RegisterForComInterop>
     <RemoveIntegerChecks>false</RemoveIntegerChecks>
-    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
-    <WarningLevel>4</WarningLevel>
     <DebugType>none</DebugType>
-    <ErrorReport>prompt</ErrorReport>
-    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System">
+    <Reference Update="System">
       <Name>System</Name>
     </Reference>
-    <Reference Include="System.Data">
+    <Reference Update="System.Data">
       <Name>System.Data</Name>
     </Reference>
-    <Reference Include="System.Drawing">
+    <Reference Update="System.Drawing">
       <Name>System.Drawing</Name>
     </Reference>
-    <Reference Include="System.Windows.Forms">
-      <Name>System.Windows.Forms</Name>
-    </Reference>
-    <Reference Include="System.XML">
+    <Reference Update="System.XML">
       <Name>System.XML</Name>
     </Reference>
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="AssemblyInfo.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="CbtHook.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="DialogBox.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Win32API.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="WindowsHook.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="WndProcRetHook.cs">
-      <SubType>Code</SubType>
-    </Compile>
-  </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PreBuildEvent>
-    </PreBuildEvent>
-    <PostBuildEvent>
-    </PostBuildEvent>
+    <AssemblyTitle>CodeProject Dialog Library</AssemblyTitle>
+    <Company>JCL</Company>
+    <Product>WindowsDialogBox</Product>
+    <Copyright>Copyright © JCL 2003</Copyright>
+    <AssemblyVersion>1.3.0.0</AssemblyVersion>
+    <FileVersion>1.3.0.0</FileVersion>
   </PropertyGroup>
 </Project>

--- a/src/AuxWinLib/Properties/AssemblyInfo.cs
+++ b/src/AuxWinLib/Properties/AssemblyInfo.cs
@@ -1,6 +1,9 @@
 ﻿using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+
+[assembly: SupportedOSPlatform("windows")]
 
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information

--- a/src/PerfLib/PerfLib.csproj
+++ b/src/PerfLib/PerfLib.csproj
@@ -1,58 +1,16 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{AB642D01-29BF-4FBC-A001-E1795AC38108}</ProjectGuid>
+    <TargetFramework>net7.0-windows</TargetFramework>
     <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>audiamus.perf</RootNamespace>
-    <AssemblyName>PerfLib</AssemblyName>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <Deterministic>true</Deterministic>
-    <TargetFrameworkProfile />
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
+    <ProjectReference Include="..\AuxLib\AuxLib.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="CpuUsage.cs" />
-    <Compile Include="PerfCallback.cs" />
-    <Compile Include="PerformanceMonitor.cs" />
-    <Compile Include="ProcessCpuCounter.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
+    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="7.0.0" />
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\AuxLib\AuxLib.csproj">
-      <Project>{64C35BCC-BF7A-47BE-89F2-7ABB470BDB0B}</Project>
-      <Name>AuxLib</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/PerfLib/Properties/AssemblyInfo.cs
+++ b/src/PerfLib/Properties/AssemblyInfo.cs
@@ -1,6 +1,9 @@
 ﻿using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+
+[assembly: SupportedOSPlatform("windows")]
 
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information

--- a/src/PropGridLib/PropGridLib.csproj
+++ b/src/PropGridLib/PropGridLib.csproj
@@ -1,54 +1,14 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{7B091DC6-75AA-403C-AD5E-EA3CB6610CD0}</ProjectGuid>
+    <TargetFramework>net7.0-windows</TargetFramework>
     <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>audiamus.aux.propgrid</RootNamespace>
-    <AssemblyName>PropGridLib</AssemblyName>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <Deterministic>true</Deterministic>
-    <TargetFrameworkProfile />
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <UseWindowsForms>true</UseWindowsForms>
+    <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Windows.Forms" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Attributes.cs" />
-    <Compile Include="BasePropertyGridAdapter.cs" />
-    <Compile Include="Descriptor.cs" />
-    <Compile Include="DynamicProperty.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="PropertySorter.cs" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/TreeDecomposition/TreeDecomposition.csproj
+++ b/src/TreeDecomposition/TreeDecomposition.csproj
@@ -1,64 +1,16 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{BBEFB463-1F6C-4D35-AF83-B5C3CEA9915E}</ProjectGuid>
+    <TargetFramework>net7.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>audiamus.aux.diagn</RootNamespace>
-    <AssemblyName>TreeDecomposition</AssemblyName>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <Deterministic>true</Deterministic>
-    <TargetFrameworkProfile />
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <LangVersion>7.1</LangVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
+    <ProjectReference Include="..\AuxLib\AuxLib.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="AbstractPrimitiveTypes.cs" />
-    <Compile Include="CustomAttributes.cs" />
-    <Compile Include="Enums.cs" />
-    <Compile Include="Interfaces.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="TreeDecomposition.cs" />
-    <Compile Include="TreeDecompositionExtension.cs" />
-    <Compile Include="ToStringConverter.cs" />
-    <Compile Include="TypeExtension.cs" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\AuxLib\AuxLib.csproj">
-      <Project>{64c35bcc-bf7a-47be-89f2-7abb470bdb0b}</Project>
-      <Name>AuxLib</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>


### PR DESCRIPTION
Hi!

Here's a minimal but as far as I can tell, well working, upgrade of all projects to .NET 7, and all nuget packages to the latest current.

Much more can be done, but all warnings, including those related to the updates have been fixed, including some obsolete warnings.

I have not tried to build the Innosetup, but it should not really change anything. It is possible to build with .NET 7 a single executable, including embedded the whole .NET 7 code, trimming away all that's not needed etc in order to not require the consumer to have .NET 7 installed for example.

I don't really think it should be a problem to ask users to go to https://dotnet.microsoft.com/en-us/download/dotnet and download .NET 7, they'll be needing it anyway in many cases.

After releasing this, it should be fairly trivial to upgrade to .NET 8 when it's released as well.